### PR TITLE
fix: only add devices that are of type Door, since these are the only…

### DIFF
--- a/custom_components/doorman/lock.py
+++ b/custom_components/doorman/lock.py
@@ -31,7 +31,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     yale_hub = YaleHub(username=username, password=password, zone_id=1)
 
-    doormans = [Doorman(i) for i in yale_hub.devices]
+    doormans = []
+
+    for device in yale_hub.devices:
+        if isinstance(device, Door):
+            doormans.append(Doorman(device))
+
     add_entities(doormans)
 
 


### PR DESCRIPTION
… ones that make sense to add in this integration

After trying to add the integration, I got some errors with "AttributeError: 'NoneType' object has no attribute 'name'". I looked into the code, and it seemed to try and add any device connected to the hub as a doorman device. I have lots of other devices connected to my hub (f.ex motion sensor), and these caused this issue. After filtering out just the Door types, the integration worked nicely.