### PR TITLE
fix: only add devices that are of type Door, since these are the only ones that make sense to add in this integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Supports:
  * Reading current state
  * Reading past state via the report API (Same as the history in the app)
  * Lock
- 
+
 Unsupported:
  * Unlock is integrated but pincode need to be sent as a kwarg "code" to the unlock function for it to work, support for function needs to be integrated into home assistant
 
@@ -23,8 +23,9 @@ Place the `custom_components` folder in your Home Assistant configuration folder
 
 add the following to configuration.yaml
 
+```
 lock:
   - platform: doorman
     username: 'xxxx@xxx.com'
     password: 'xxxxxxxxxxxx'
-
+```

--- a/custom_components/doorman/lock.py
+++ b/custom_components/doorman/lock.py
@@ -31,7 +31,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     yale_hub = YaleHub(username=username, password=password, zone_id=1)
 
-    doormans = [Doorman(i) for i in yale_hub.devices]
+    doormans = []
+
+    for device in yale_hub.devices:
+        if isinstance(device, Door):
+            doormans.append(Doorman(device))
+
     add_entities(doormans)
 
 


### PR DESCRIPTION
After trying to add the integration, I got some errors with "AttributeError: 'NoneType' object has no attribute 'name'". I looked into the code, and it seemed to try and add any device connected to the hub as a doorman device. I have lots of other devices connected to my hub (f.ex motion sensor), and these caused this issue. After filtering out just the Door types, the integration worked nicely.