### PR TITLE
fix: only add devices that are of type Door, since these are the only ones that make sense to add in this integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Supports:
  * Reading current state
  * Reading past state via the report API (Same as the history in the app)
  * Lock
- 
+
 Unsupported:
  * Unlock is integrated but pincode need to be sent as a kwarg "code" to the unlock function for it to work, support for function needs to be integrated into home assistant
 
@@ -23,8 +23,9 @@ Place the `custom_components` folder in your Home Assistant configuration folder
 
 add the following to configuration.yaml
 
+```
 lock:
   - platform: doorman
     username: 'xxxx@xxx.com'
     password: 'xxxxxxxxxxxx'
-
+```

--- a/custom_components/doorman/lock.py
+++ b/custom_components/doorman/lock.py
@@ -31,7 +31,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     yale_hub = YaleHub(username=username, password=password, zone_id=1)
 
-    doormans = [Doorman(i) for i in yale_hub.devices]
+    doormans = []
+
+    for device in yale_hub.devices:
+        if isinstance(device, Door):
+            doormans.append(Doorman(device))
+
     add_entities(doormans)
 
 

--- a/custom_components/doorman/lock.py
+++ b/custom_components/doorman/lock.py
@@ -31,11 +31,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     yale_hub = YaleHub(username=username, password=password, zone_id=1)
 
-    doormans = []
-
-    for device in yale_hub.devices:
-        if isinstance(device, Door):
-            doormans.append(Doorman(device))
+    doormans = [Doorman(i) for i in yale_hub.devices]
 
     add_entities(doormans)
 

--- a/custom_components/doorman/yale/yale_hub.py
+++ b/custom_components/doorman/yale/yale_hub.py
@@ -31,16 +31,18 @@ class YaleHub:
         new_devices = []
         devices = data.get("device_status")
         for device in devices:
-            yale_device = DeviceFactory.Create(
-                yale_hub=self,
-                device_id=device.get("device_id"),
-                device_type=device.get("type"),
-                name=device.get("name"),
-                area=device.get("area"),
-                zone=device.get("no"))
+            dev_type=device.get("type")
+            if dev_type == "device_type.door_lock":
+                yale_device = DeviceFactory.Create(
+                    yale_hub=self,
+                    device_id=device.get("device_id"),
+                    device_type=dev_type,
+                    name=device.get("name"),
+                    area=device.get("area"),
+                    zone=device.get("no"))
 
-            self._LOGGER.info(f"Adding device {yale_device.name}")
-            new_devices.append(yale_device)
+                self._LOGGER.info(f"Adding device {yale_device.name}")
+                new_devices.append(yale_device)
         return new_devices
 
     def get_state(self, device_id):


### PR DESCRIPTION
After trying to add the integration, I got some errors with "AttributeError: 'NoneType' object has no attribute 'name'". Checking the type seems to fix the issue.
